### PR TITLE
Enable the stream callback function to get complete chunk information

### DIFF
--- a/openai/init.moon
+++ b/openai/init.moon
@@ -83,7 +83,7 @@ parse_chat_response = types.partial {
 
 
 parse_completion_chunk = types.partial {
-  object: "chat.completion.chunk"
+  --object: "chat.completion.chunk"
   -- not sure of the whole range of chunks, so for now we strictly parse an append
   choices: types.shape {
     types.partial {
@@ -190,7 +190,8 @@ class ChatSession
 
       parts = {}
       f = @client\create_stream_filter (c) ->
-        table.insert parts, c.content
+        if c = parse_completion_chunk c
+          table.insert parts, c.content
 
       f response
       message = {
@@ -250,7 +251,7 @@ class OpenAI
             break
 
           accumulation_buffer = rest
-          if chunk = parse_completion_chunk cjson.decode json_blob
+          if chunk = cjson.decode json_blob
             chunk_callback chunk
 
       ...


### PR DESCRIPTION
And do not demand `object: "chat.completion.chunk"` within the chunk object to support not fully OpenAI-compliant services

Close #5